### PR TITLE
Fix: Improve dark mode color contrast and readability

### DIFF
--- a/src/app/components/BabyLogCharts.tsx
+++ b/src/app/components/BabyLogCharts.tsx
@@ -194,7 +194,27 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
                 cx="50%"
                 cy="50%"
                 labelLine={false}
-                label={{ fill: "var(--recharts-text-color)", fontSize: "0.875rem", formatter: ({ name, value, percent }) => `${name}: ${value}回 (${(percent * 100).toFixed(1)}%)` }}
+                label={(props) => {
+                  const { cx, cy, midAngle, outerRadius, name, value, percent } = props;
+                  const RADIAN = Math.PI / 180;
+                  // Calculate a position slightly outside the pie slice for the label
+                  const radius = outerRadius * 1.1; // Adjust multiplier for distance
+                  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+                  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+                  return (
+                    <text
+                      x={x}
+                      y={y}
+                      fill="var(--recharts-text-color)"
+                      fontSize="0.875rem" // 14px
+                      textAnchor={x > cx ? 'start' : 'end'} // Anchor text based on position relative to center
+                      dominantBaseline="central"
+                    >
+                      {`${name}: ${value}回 (${(percent * 100).toFixed(1)}%)`}
+                    </text>
+                  );
+                }}
                 outerRadius={80}
                 fill="#8884d8"
                 dataKey="value"

--- a/src/app/components/BabyLogCharts.tsx
+++ b/src/app/components/BabyLogCharts.tsx
@@ -29,10 +29,10 @@ interface BabyLogChartsProps {
   logEntries: BabyLogEntry[];
 }
 
-const COLORS = {
-  urination: '#3B82F6', // blue
-  defecation: '#F59E0B', // amber
-};
+// const COLORS = {
+//   urination: '#3B82F6', // blue
+//   defecation: '#F59E0B', // amber
+// };
 
 export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
   // 日別データの集計
@@ -88,8 +88,8 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
     const defecationCount = logEntries.filter((entry) => entry.type === 'defecation').length;
 
     return [
-      { name: 'おしっこ', value: urinationCount, color: COLORS.urination },
-      { name: 'うんち', value: defecationCount, color: COLORS.defecation },
+      { name: 'おしっこ', value: urinationCount, color: 'var(--chart-color-urination)' },
+      { name: 'うんち', value: defecationCount, color: 'var(--chart-color-defecation)' },
     ];
   }, [logEntries]);
 
@@ -109,28 +109,28 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
 
   if (logEntries.length === 0) {
     return (
-      <div className="bg-gray-50 p-6 rounded-lg">
+      <div className="bg-gray-50 dark:bg-gray-800 p-6 rounded-lg">
         <h2 className="text-xl font-bold mb-4">📊 グラフ</h2>
-        <p className="text-gray-500">記録がありません。まずは記録を追加してください。</p>
+        <p className="text-gray-600 dark:text-gray-400">記録がありません。まずは記録を追加してください。</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-50 p-6 rounded-lg">
+    <div className="bg-gray-50 dark:bg-gray-800 p-6 rounded-lg">
       <h2 className="text-xl font-bold mb-6">📊 グラフ</h2>
 
       {/* 今日の統計 */}
       <div className="mb-8">
         <h3 className="text-lg font-semibold mb-3">今日の記録</h3>
         <div className="grid grid-cols-2 gap-4">
-          <div className="bg-blue-100 p-4 rounded-lg text-center">
-            <div className="text-2xl font-bold text-blue-600">{todayData.urination}</div>
-            <div className="text-sm text-blue-600">おしっこ</div>
+          <div className="bg-blue-100 dark:bg-blue-800 p-4 rounded-lg text-center">
+            <div className="text-2xl font-bold text-blue-600 dark:text-blue-300">{todayData.urination}</div>
+            <div className="text-sm text-blue-600 dark:text-blue-300">おしっこ</div>
           </div>
-          <div className="bg-amber-100 p-4 rounded-lg text-center">
-            <div className="text-2xl font-bold text-amber-600">{todayData.defecation}</div>
-            <div className="text-sm text-amber-600">うんち</div>
+          <div className="bg-amber-100 dark:bg-amber-800 p-4 rounded-lg text-center">
+            <div className="text-2xl font-bold text-amber-600 dark:text-amber-300">{todayData.defecation}</div>
+            <div className="text-sm text-amber-600 dark:text-amber-300">うんち</div>
           </div>
         </div>
       </div>
@@ -141,13 +141,13 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={dailyData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="おしっこ" fill={COLORS.urination} />
-              <Bar dataKey="うんち" fill={COLORS.defecation} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--recharts-grid-color)" />
+              <XAxis dataKey="date" tick={{ fill: "var(--recharts-text-color)" }} />
+              <YAxis tick={{ fill: "var(--recharts-text-color)" }} />
+              <Tooltip contentStyle={{ backgroundColor: "var(--tooltip-bg-color)", color: "var(--tooltip-text-color)", borderRadius: "0.375rem", boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)" }} cursor={{ fill: "var(--tooltip-cursor-color)" }} />
+              <Legend wrapperStyle={{ color: "var(--recharts-text-color)" }} />
+              <Bar dataKey="おしっこ" fill="var(--chart-color-urination)" />
+              <Bar dataKey="うんち" fill="var(--chart-color-defecation)" />
             </BarChart>
           </ResponsiveContainer>
         </div>
@@ -159,24 +159,24 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={hourlyData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="hour" interval={2} />
-              <YAxis />
-              <Tooltip />
-              <Legend />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--recharts-grid-color)" />
+              <XAxis dataKey="hour" interval={2} tick={{ fill: "var(--recharts-text-color)" }} />
+              <YAxis tick={{ fill: "var(--recharts-text-color)" }} />
+              <Tooltip contentStyle={{ backgroundColor: "var(--tooltip-bg-color)", color: "var(--tooltip-text-color)", borderRadius: "0.375rem", boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)" }} cursor={{ fill: "var(--tooltip-cursor-color)" }} />
+              <Legend wrapperStyle={{ color: "var(--recharts-text-color)" }} />
               <Line
                 type="monotone"
                 dataKey="おしっこ"
-                stroke={COLORS.urination}
+                stroke="var(--chart-color-urination)"
                 strokeWidth={2}
-                dot={{ fill: COLORS.urination }}
+                dot={{ fill: "var(--chart-color-urination)" }}
               />
               <Line
                 type="monotone"
                 dataKey="うんち"
-                stroke={COLORS.defecation}
+                stroke="var(--chart-color-defecation)"
                 strokeWidth={2}
-                dot={{ fill: COLORS.defecation }}
+                dot={{ fill: "var(--chart-color-defecation)" }}
               />
             </LineChart>
           </ResponsiveContainer>
@@ -194,7 +194,7 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
                 cx="50%"
                 cy="50%"
                 labelLine={false}
-                label={({ name, value, percent }) => `${name}: ${value}回 (${(percent * 100).toFixed(1)}%)`}
+                label={{ fill: "var(--recharts-text-color)", fontSize: "0.875rem", formatter: ({ name, value, percent }) => `${name}: ${value}回 (${(percent * 100).toFixed(1)}%)` }}
                 outerRadius={80}
                 fill="#8884d8"
                 dataKey="value"
@@ -203,7 +203,7 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
                   <Cell key={`cell-${index}`} fill={entry.color} />
                 ))}
               </Pie>
-              <Tooltip />
+              <Tooltip contentStyle={{ backgroundColor: "var(--tooltip-bg-color)", color: "var(--tooltip-text-color)", borderRadius: "0.375rem", boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)" }} cursor={{ fill: "var(--tooltip-cursor-color)" }} />
             </PieChart>
           </ResponsiveContainer>
         </div>
@@ -211,18 +211,18 @@ export default function BabyLogCharts({ logEntries }: BabyLogChartsProps) {
 
       {/* 統計情報 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-white p-4 rounded-lg border">
-          <div className="text-sm text-gray-500">総記録数</div>
+        <div className="bg-white dark:bg-gray-700 p-4 rounded-lg border">
+          <div className="text-sm text-gray-600 dark:text-gray-300">総記録数</div>
           <div className="text-2xl font-bold">{logEntries.length}</div>
         </div>
-        <div className="bg-white p-4 rounded-lg border">
-          <div className="text-sm text-gray-500">1日平均</div>
+        <div className="bg-white dark:bg-gray-700 p-4 rounded-lg border">
+          <div className="text-sm text-gray-600 dark:text-gray-300">1日平均</div>
           <div className="text-2xl font-bold">
             {dailyData.length > 0 ? (logEntries.length / 7).toFixed(1) : 0}
           </div>
         </div>
-        <div className="bg-white p-4 rounded-lg border">
-          <div className="text-sm text-gray-500">最多記録日</div>
+        <div className="bg-white dark:bg-gray-700 p-4 rounded-lg border">
+          <div className="text-sm text-gray-600 dark:text-gray-300">最多記録日</div>
           <div className="text-lg font-bold">
             {dailyData.reduce((max, day) => (day.total > max.total ? day : max), dailyData[0])?.date || '-'}
           </div>

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -56,8 +56,8 @@ export default function DemoPage() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">赤ちゃんのトイレログ（デモ版）</h1>
-      <div className="mb-4 p-4 bg-blue-100 rounded">
-        <p className="text-sm text-blue-800">
+      <div className="mb-4 p-4 bg-blue-100 rounded dark:bg-blue-800">
+        <p className="text-sm text-blue-800 dark:text-blue-300">
           このデモ版では、データはブラウザのローカルストレージに保存されます。
           日時を指定して記録できる機能をテストできます。
         </p>
@@ -74,7 +74,7 @@ export default function DemoPage() {
             <option value="defecation">うんち</option>
           </select>
           <div className="flex flex-col">
-            <label htmlFor="datetime" className="text-sm text-gray-600 mb-1">
+            <label htmlFor="datetime" className="text-sm text-gray-600 dark:text-gray-400 mb-1">
               日時
             </label>
             <input
@@ -82,7 +82,7 @@ export default function DemoPage() {
               type="datetime-local"
               value={datetime}
               onChange={(e) => setDatetime(e.target.value)}
-              className="border p-2 rounded"
+              className="border p-2 rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 dark:focus:ring-blue-500 dark:focus:border-blue-500"
               required
             />
           </div>
@@ -95,11 +95,11 @@ export default function DemoPage() {
       <div>
         <h2 className="text-xl font-bold mb-2">ログエントリ</h2>
         {logEntries.length === 0 ? (
-          <p className="text-gray-500">まだ記録がありません。</p>
+          <p className="text-gray-500 dark:text-gray-400">まだ記録がありません。</p>
         ) : (
           <ul>
             {logEntries.map((entry) => (
-              <li key={entry.id} className="mb-1 flex justify-between items-center p-2 bg-gray-50 rounded">
+              <li key={entry.id} className="mb-1 flex justify-between items-center p-2 bg-gray-50 dark:bg-gray-700 rounded">
                 <span>
                   {entry.type === 'urination' ? 'おしっこ' : 'うんち'} at {new Date(entry.timestamp).toLocaleString('ja-JP')}
                 </span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,9 +10,9 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
+    --foreground-rgb: 243, 244, 246;
+    --background-start-rgb: 17, 24, 39;
+    --background-end-rgb: 17, 24, 39;
   }
 }
 
@@ -30,7 +30,27 @@ body {
   .text-balance {
     text-wrap: balance;
   }
+  :root {
+    --recharts-text-color: #6b7280; /* gray-500 */
+    --recharts-grid-color: rgba(209, 213, 219, 0.5); /* gray-300 with 50% opacity */
+    --tooltip-bg-color: #ffffff; /* white */
+    --tooltip-text-color: #374151; /* gray-700 */
+    --tooltip-cursor-color: rgba(0, 0, 0, 0.1); /* black with 10% opacity */
+    --chart-color-urination: #3B82F6; /* Tailwind blue-500 */
+    --chart-color-defecation: #F59E0B; /* Tailwind amber-500 */
+  }
 @media (prefers-color-scheme: dark) {
+  :root {
+    /* --recharts-text-color is already set by --foreground-rgb which is now off-white */
+    /* We can explicitly define it if we want a different color for charts text */
+    --recharts-text-color: #d1d5db; /* gray-300, for better contrast on dark gray */
+    --recharts-grid-color: rgba(75, 85, 99, 0.3); /* gray-600 with 30% opacity */
+    --tooltip-bg-color: #374151; /* gray-700 */
+    --tooltip-text-color: #f3f4f6; /* gray-100 */
+    --tooltip-cursor-color: rgba(255, 255, 255, 0.1); /* white with 10% opacity */
+    --chart-color-urination: #60A5FA; /* Tailwind blue-400, for better contrast */
+    --chart-color-defecation: #FBBF24; /* Tailwind amber-400, slightly lighter */
+  }
   select {
     background-color: rgb(var(--background-start-rgb));
     color: rgb(var(--foreground-rgb));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,14 +105,14 @@ export default function BabyLogPage() {
         <h1 className="text-3xl font-bold">🍼 赤ちゃんのトイレログ</h1>
         <a
           href="/demo-data"
-          className="text-sm bg-gray-100 hover:bg-gray-200 px-3 py-2 rounded transition-colors duration-200"
+          className="text-sm bg-gray-100 hover:bg-gray-200 px-3 py-2 rounded transition-colors duration-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300"
         >
           🧪 デモデータ
         </a>
       </div>
       
       {/* 記録フォーム */}
-      <div className="bg-white p-6 rounded-lg shadow-md mb-6">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md mb-6">
         <h2 className="text-xl font-bold mb-4">📝 新しい記録</h2>
         <form onSubmit={handleSubmit}>
           <div className="flex flex-col space-y-2 md:flex-row md:space-y-0 md:space-x-2">
@@ -125,7 +125,7 @@ export default function BabyLogPage() {
               <option value="defecation">💩 うんち</option>
             </select>
             <div className="flex flex-col">
-              <label htmlFor="datetime" className="text-sm text-gray-600 mb-1">
+              <label htmlFor="datetime" className="text-sm text-gray-600 dark:text-gray-400 mb-1">
                 日時
               </label>
               <input
@@ -133,7 +133,7 @@ export default function BabyLogPage() {
                 type="datetime-local"
                 value={datetime}
                 onChange={(e) => setDatetime(e.target.value)}
-                className="border p-2 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                className="border p-2 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 dark:focus:ring-blue-500 dark:focus:border-blue-500"
                 required
               />
             </div>
@@ -153,14 +153,14 @@ export default function BabyLogPage() {
       </div>
 
       {/* ログエントリ一覧 */}
-      <div className="bg-white p-6 rounded-lg shadow-md">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
         <h2 className="text-xl font-bold mb-4">📋 最近の記録</h2>
         {logEntries.length === 0 ? (
-          <p className="text-gray-500 text-center py-8">まだ記録がありません。上のフォームから記録を追加してください。</p>
+          <p className="text-gray-500 dark:text-gray-400 text-center py-8">まだ記録がありません。上のフォームから記録を追加してください。</p>
         ) : (
           <div className="space-y-2 max-h-96 overflow-y-auto">
             {logEntries.slice(0, 20).map((entry) => (
-              <div key={entry.id} className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+              <div key={entry.id} className="flex justify-between items-center p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
                 <span className="flex items-center space-x-2">
                   <span className="text-lg">
                     {entry.type === 'urination' ? '💧' : '💩'}
@@ -168,7 +168,7 @@ export default function BabyLogPage() {
                   <span>
                     {entry.type === 'urination' ? 'おしっこ' : 'うんち'}
                   </span>
-                  <span className="text-gray-500">
+                  <span className="text-gray-500 dark:text-gray-400">
                     {new Date(entry.timestamp).toLocaleString('ja-JP')}
                   </span>
                 </span>
@@ -181,7 +181,7 @@ export default function BabyLogPage() {
               </div>
             ))}
             {logEntries.length > 20 && (
-              <p className="text-gray-500 text-center text-sm">
+              <p className="text-gray-500 dark:text-gray-400 text-center text-sm">
                 最新の20件を表示しています（全{logEntries.length}件）
               </p>
             )}


### PR DESCRIPTION
This commit addresses issues with color visibility in dark mode across the application.

Key changes include:

1.  **Global Styles (`globals.css`):**
    *   Introduced a softer dark mode theme with a dark gray background (Tailwind gray-900) and off-white text (Tailwind gray-100) for better eye comfort.
    *   Defined CSS variables for Recharts elements (grid, text, tooltips) and chart series colors, with specific variants for dark mode to ensure proper contrast.
    *   Updated dark mode styling for `select` elements.

2.  **Chart Component (`BabyLogCharts.tsx`):**
    *   Applied Tailwind `dark:` utility classes for component backgrounds and static text.
    *   Integrated CSS variables for all chart elements (axes, grid, tooltips, legend, pie labels) and data series colors (urination/defecation) to ensure they adapt to dark mode.
    *   The "urination" color (blue) and "defecation" color (amber) are now lighter in dark mode for better visibility on dark backgrounds.

3.  **Main Pages (`page.tsx`, `demo/page.tsx`):**
    *   Applied Tailwind `dark:` utility classes to various elements including cards, containers, text, form inputs, and informational banners to ensure they are styled correctly in dark mode.

These changes significantly enhance your experience in dark mode by providing better color contrast and overall visual appeal.