### PR TITLE
Fix: Resolve auth state synchronization issue causing login loop

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -150,50 +150,17 @@ export default function BabyLogPage() {
     }
   };
 
-  if (authLoading) {
-    // If authentication is in progress, show an "Authenticating..." message.
-    // This is the highest priority check.
+  // Display loading indicator while checking auth or if user is null (before redirect)
+  // or while logs are loading
+  if (authLoading || isLoadingLogs || !user) {
     return (
       <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-        <p>Authenticating...</p>
+        <p>Loading...</p>
       </div>
     );
   }
 
-  // If authentication is complete (authLoading is false) but there is no user,
-  // it means the user is not logged in.
-  // The useEffect hook:
-  //   useEffect(() => {
-  //     if (!authLoading && !user) {
-  //       router.push('/login');
-  //     }
-  //   }, [user, authLoading, router]);
-  // will handle the redirection to the login page.
-  // We return a message here to prevent rendering the rest of the page
-  // or other loading states like isLoadingLogs, and to avoid a flash of content.
-  if (!user) {
-    return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-        <p>Redirecting to login...</p>
-      </div>
-    );
-  }
-
-  // If authentication is complete (authLoading is false) and a user is present,
-  // then check if logs are being loaded.
-  if (isLoadingLogs) {
-    return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-        <p>Loading data...</p>
-      </div>
-    );
-  }
-
-  // If all checks above have passed, it means:
-  // - Authentication is complete (authLoading is false).
-  // - A user is logged in (user object is present).
-  // - Log data has been loaded (isLoadingLogs is false).
-  // Now it's safe to render the actual page content.
+  // Render the actual page content here if user is authenticated
   return (
     <div className="container mx-auto p-4 max-w-6xl">
       <div className="flex justify-between items-center mb-6">

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -28,23 +28,17 @@ export function useAuth() {
   }, []);
 
   const signUp = async (credentials: SignUpWithPasswordCredentials) => {
-    setLoading(true);
     const { data, error } = await supabase.auth.signUp(credentials);
-    setLoading(false);
     return { data, error };
   };
 
   const signIn = async (credentials: SignInWithPasswordCredentials) => {
-    setLoading(true);
     const { data, error } = await supabase.auth.signInWithPassword(credentials);
-    setLoading(false);
     return { data, error };
   };
 
   const signOut = async () => {
-    setLoading(true);
     const { error } = await supabase.auth.signOut();
-    setLoading(false);
     return { error };
   };
 


### PR DESCRIPTION
The infinite redirect loop between the login and application pages was caused by a race condition in `src/hooks/useAuth.ts`. The `signIn`, `signUp`, and `signOut` functions were manually setting the `loading` state to `false` before the `onAuthStateChange` event could reliably update the `user` state. This led to inconsistencies where components would perceive `loading` as `false` but `user` as `null` transiently, triggering erroneous redirects.

This commit addresses the issue by:
1. Modifying `src/hooks/useAuth.ts`: Removed the explicit `setLoading(true)` and `setLoading(false)` calls from `signIn`, `signUp`, and `signOut`. The `loading` state is now exclusively managed by the initial `getSession` call and the `onAuthStateChange` listener, ensuring `loading` only becomes `false` after `user` state is definitively set.
2. Simplifying `src/app/page.tsx`: Reverted the loading logic in the main application page to its simpler, original form. This change was made to isolate and confirm the fix in `useAuth.ts`.

These changes ensure that the authentication state (`user` and `loading`) is updated atomically, preventing the race condition and resolving the infinite redirect loop.