### PR TITLE
feat: Implement landing page and dashboard separation

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,39 @@
-import { type NextRequest } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
 import { updateSession } from '@/utils/supabase/middleware'
+import { createClient } from '@/utils/supabase/server' // Assuming server client can be created here
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request)
+  // First, refresh the session
+  const response = await updateSession(request)
+
+  // Create a Supabase client to get the user
+  // Note: This might need to use request/response from updateSession if they are modified
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { pathname } = request.nextUrl
+
+  // If the user is not authenticated and trying to access /dashboard
+  if (!user && pathname.startsWith('/dashboard')) {
+    // Redirect to login page
+    const url = request.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
+
+  // If the user is authenticated and trying to access /login or / (landing)
+  //
+  // This part is commented out as it was not explicitly requested.
+  // Depending on UX, you might want to redirect logged-in users away from public pages.
+  // if (user && (pathname === '/login' || pathname === '/')) {
+  //   const url = request.nextUrl.clone()
+  //   url.pathname = '/dashboard'
+  //   return NextResponse.redirect(url)
+  // }
+
+  return response
 }
 
 export const config = {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
-import { createClient } from '../utils/supabase/server'
-import BabyLogContent from './components/BabyLogContent'
+import { createClient } from '../../utils/supabase/server' // Updated path
+import BabyLogContent from '../components/BabyLogContent' // Updated path
 
 export default async function BabyLogPage() {
   const supabase = await createClient()

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '../utils/supabase/server'
+import BabyLogContent from './components/BabyLogContent'
+
+export default async function BabyLogPage() {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getUser()
+
+  if (error) {
+    console.error('Authentication error:', error.message)
+    redirect('/login')
+  }
+
+  if (!data?.user) {
+    console.warn('No authenticated user found')
+    redirect('/login')
+  }
+
+  return <BabyLogContent user={data.user} />
+}

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export default function LandingPage() {
+  return (
+    <div>
+      <h1>Welcome to Our Application!</h1>
+      <p>
+        Join us and explore the amazing features we offer. Sign up for a new
+        account or log in if you already have one.
+      </p>
+      <div>
+        <Link href="/login">
+          <button>Login</button>
+        </Link>
+        {/* Add a signup button/link here if/when signup functionality exists */}
+      </div>
+    </div>
+  );
+}

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -3,16 +3,15 @@ import Link from 'next/link';
 export default function LandingPage() {
   return (
     <div>
-      <h1>Welcome to Our Application!</h1>
+      <h1>ようこそ！</h1>
       <p>
-        Join us and explore the amazing features we offer. Sign up for a new
-        account or log in if you already have one.
+        素晴らしい機能の数々をぜひ体験してください。アカウントをお持ちでない方は新規登録、既にお持ちの方はログインしてください。
       </p>
       <div>
         <Link href="/login">
-          <button>Login</button>
+          <button>ログイン</button>
         </Link>
-        {/* Add a signup button/link here if/when signup functionality exists */}
+        {/* サインアップ機能が実装されたら、ここにサインアップボタン/リンクを追加します */}
       </div>
     </div>
   );

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -21,8 +21,10 @@ export async function login(formData: FormData) {
     redirect('/error')
   }
 
-  revalidatePath('/', 'layout')
-  redirect('/')
+  revalidatePath('/dashboard', 'layout') // Update revalidatePath for login
+  redirect('/dashboard')
+  revalidatePath('/dashboard', 'layout') // Update revalidatePath for signup
+  redirect('/dashboard')
 }
 
 export async function signup(formData: FormData) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,5 @@
-import { redirect } from 'next/navigation'
-import { createClient } from '../utils/supabase/server'
-import BabyLogContent from './components/BabyLogContent'
+import LandingPage from './landing/page';
 
-export default async function BabyLogPage() {
-  const supabase = await createClient()
-  const { data, error } = await supabase.auth.getUser()
-  
-  if (error) {
-    console.error('Authentication error:', error.message)
-    redirect('/login')
-  }
-  
-  if (!data?.user) {
-    console.warn('No authenticated user found')
-    redirect('/login')
-  }
-  
-  return <BabyLogContent user={data.user} />
+export default function HomePage() {
+  return <LandingPage />;
 }


### PR DESCRIPTION
- Created a new landing page at `/`.
- Moved the existing baby log content to a new `/dashboard` route.
- Updated middleware to protect the `/dashboard` route and allow public access to the landing page.
- Updated navigation and redirects to reflect the new structure.

Note: I was unable to update the redirect after login/signup in `src/app/login/actions.ts`. It still points to `/` instead of `/dashboard`.