### PR TITLE
Fix: Improve login flow and button behavior

### DIFF
--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -23,8 +23,6 @@ export async function login(formData: FormData) {
 
   revalidatePath('/dashboard', 'layout') // Update revalidatePath for login
   redirect('/dashboard')
-  revalidatePath('/dashboard', 'layout') // Update revalidatePath for signup
-  redirect('/dashboard')
 }
 
 export async function signup(formData: FormData) {

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -1,10 +1,22 @@
 import { render, screen } from '@testing-library/react';
 import LoginPage from './page';
 import '@testing-library/jest-dom';
+import { AuthProvider } from '@/contexts/AuthContext'; // Import AuthProvider
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
 
 describe('LoginPage', () => {
   it('renders all form elements correctly', () => {
-    render(<LoginPage />);
+    render(
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>
+    );
 
     // Check for the title
     expect(screen.getByRole('heading', { name: /Login/i })).toBeInTheDocument();

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,20 @@
+"use client"
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthContext } from '@/contexts/AuthContext';
 import { login, signup } from './actions'
 
 export default function LoginPage() {
+  const { user, loading } = useAuthContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && user) {
+      router.push('/dashboard');
+    }
+  }, [user, loading, router]);
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
       <form className="p-8 bg-white rounded-lg shadow-md w-full max-w-sm">


### PR DESCRIPTION
- Redirect logged-in users from /login to /dashboard. This prevents users who are already authenticated from viewing the login page.
- Clean up login server action: Removed redundant revalidatePath and redirect calls in the login server action for clarity and to prevent potential issues.

The core AuthButton component already correctly displays Login/Logout based on auth state. These changes ensure that you are directed appropriately post-login and that the login page itself doesn't cause confusion for authenticated users.