### PR TITLE
I've replaced '赤ちゃん' with '子ども' in the UI text.

### DIFF
--- a/src/app/components/BabyLogContent.tsx
+++ b/src/app/components/BabyLogContent.tsx
@@ -124,7 +124,7 @@ export default function BabyLogContent({ user }: { user: User }) {
   return (
     <div className="container mx-auto p-4 max-w-6xl">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold">🍼 赤ちゃんのトイレログ</h1>
+        <h1 className="text-3xl font-bold">🍼 子どものトイレログ</h1>
         {/* The AuthButton could be placed here or in the main layout */}
         {/* For example: <AuthButton /> */}
         <a

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -55,7 +55,7 @@ export default function DemoPage() {
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">赤ちゃんのトイレログ（デモ版）</h1>
+      <h1 className="text-2xl font-bold mb-4">子どものトイレログ（デモ版）</h1>
       <div className="mb-4 p-4 bg-blue-100 rounded dark:bg-blue-800">
         <p className="text-sm text-blue-800 dark:text-blue-300">
           このデモ版では、データはブラウザのローカルストレージに保存されます。

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -11,10 +11,10 @@ export default function LandingPage() {
       <section style={{ marginBottom: '20px', marginTop: '20px' }}>
         <h2 style={{ fontSize: '1.5em', marginBottom: '10px' }}>特徴</h2>
         <ul style={{ listStylePosition: 'inside' }}>
-          <li style={{ marginBottom: '5px' }}>赤ちゃんのおしっことうんちを記録</li>
+          <li style={{ marginBottom: '5px' }}>子どものおしっことうんちを記録</li>
           <li style={{ marginBottom: '5px' }}>記録されたログを表示</li>
           <li style={{ marginBottom: '5px' }}>日本語対応のユーザーインターフェース</li>
-          <li style={{ marginBottom: '5px' }}><strong>ユーザー認証</strong>: Supabaseを利用したメールアドレスとパスワードによるサインアップ・サインイン機能。ユーザーはアカウントを作成して、自分の赤ちゃんの活動記録を管理できます。</li>
+          <li style={{ marginBottom: '5px' }}><strong>ユーザー認証</strong>: Supabaseを利用したメールアドレスとパスワードによるサインアップ・サインイン機能。ユーザーはアカウントを作成して、自分の子どもの活動記録を管理できます。</li>
         </ul>
       </section>
       <div>


### PR DESCRIPTION
This change replaces all instances of '赤ちゃん' (baby) with '子ども' (child) in the user interface, as you requested.

Files modified:
- src/app/components/BabyLogContent.tsx
- src/app/demo/page.tsx
- src/app/landing/page.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated headings and feature descriptions to use "子ども" (child) instead of "赤ちゃん" (baby) across the main log, demo page, and landing page for improved consistency in terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->